### PR TITLE
Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,20 @@ Adds a few right click options for various documents:
 ### Items
 
 - Adds a "Display to chat" button, which sends a chat message in the same way rolling the item from the actor
+
+### Scene
+
+- Adds a menu to the context dropdown for the Scene Directory menus to shut all doors in the selected scene to prepare it for a fresh visit from characters. The Doors that are currently locked remain locked, and are not closed.
+- Adds a menu to the context dropdown for the Scene Directory menus to delete fog in the selected scene to prepare it for a fresh visit from characters. I find it useful after QAing a new map for holes in walls/doors and checking lighting, etc.
+
+## Installation
+
+It's always easiest to install modules from the in game add-on browser.
+
+To install this module manually:
+1.  Inside the Foundry "Configuration and Setup" screen, click "Add-on Modules"
+2.  Click "Install Module"
+3.  In the "Manifest URL" field, paste the following url:
+`https://raw.githubusercontent.com/kandashi/sidebar-context/master/module.json`
+4.  Click 'Install' and wait for installation to complete
+5.  Don't forget to enable the module in game using the "Manage Module" button

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Adds a few right click options for various documents:
 
 - Adds a menu to the context dropdown for the Scene Directory menus to shut all doors in the selected scene to prepare it for a fresh visit from characters. The Doors that are currently locked remain locked, and are not closed.
 - Adds a menu to the context dropdown for the Scene Directory menus to delete fog in the selected scene to prepare it for a fresh visit from characters. I find it useful after QAing a new map for holes in walls/doors and checking lighting, etc.
+- Add on the folder scene context options the two options for hide all the scene on the naviagtion bar or show all.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Sidebar Context
 
-![Sidebar Context](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkandashi%2Fleague-repo-status%2Fshields-endpoint%2Fsidebar-context.json&style=for-the-badge)
-
 ![Latest Release Download Count](https://img.shields.io/github/downloads/kandashi/sidebar-context/latest/module.zip?color=2b82fc&label=DOWNLOADS&style=for-the-badge) 
 
 [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fsidebar-context&colorB=006400&style=for-the-badge)](https://forge-vtt.com/bazaar#package=sidebar-context) 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-![](https://img.shields.io/badge/Foundry-v0.8.6-informational)
-<!--- Downloads @ Latest Badge -->
-<!--- replace <user>/<repo> with your username/repository -->
-<!--- ![Latest Release Download Count](https://img.shields.io/github/downloads/<user>/<repo>/latest/module.zip) -->
+# Sidebar Context
 
-<!--- Forge Bazaar Install % Badge -->
-<!--- replace <your-module-name> with the `name` in your manifest -->
-<!--- ![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2F<your-module-name>&colorB=4aa94a) -->
+![Sidebar Context](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkandashi%2Fleague-repo-status%2Fshields-endpoint%2Fsidebar-context.json&style=for-the-badge)
+
+![Latest Release Download Count](https://img.shields.io/github/downloads/kandashi/sidebar-context/latest/module.zip?color=2b82fc&label=DOWNLOADS&style=for-the-badge) 
+
+[![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fsidebar-context&colorB=006400&style=for-the-badge)](https://forge-vtt.com/bazaar#package=sidebar-context) 
+
+![Foundry Core Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkandashi%2Fsidebar-context%2Fmaster%2Fmodule.json&label=Foundry%20Version&query=$.compatibleCoreVersion&colorB=orange&style=for-the-badge)
+
+![Latest Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkandashi%2Fsidebar-context%2Fmaster%2Fmodule.json&label=Latest%20Release&prefix=v&query=$.version&colorB=red&style=for-the-badge)
+
+[![Foundry Hub Endorsements](https://img.shields.io/endpoint?logoColor=white&url=https%3A%2F%2Fwww.foundryvtt-hub.com%2Fwp-json%2Fhubapi%2Fv1%2Fpackage%2Fsidebar-context%2Fshield%2Fendorsements&style=for-the-badge)](https://www.foundryvtt-hub.com/package/sidebar-context/)
 
 Adds a few right click options for various documents:
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -6,5 +6,7 @@
     "sidebar-context.updateChildrenTitle": "Update all token data",
     "sidebar-context.updateChildrenContent": "This will update all tokens created from this actor, to match the new prototype token data",
     "sidebar-context.resetDoors": "Reset Doors",
-    "sidebar-context.resetFog": "Reset Fog"
+    "sidebar-context.resetFog": "Reset Fog",
+    "sidebar-context.showNavAll": "Show all scenes in navigation bar",
+    "sidebar-context.hideNavAll": "Hide all scenes in navigation bar"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -4,5 +4,7 @@
     "sidebar-context.displayChat": "Display in Chat",
     "sidebar-context.updateChildren": "Update Child Tokens",
     "sidebar-context.updateChildrenTitle": "Update all token data",
-    "sidebar-context.updateChildrenContent": "This will update all tokens created from this actor, to match the new prototype token data"
+    "sidebar-context.updateChildrenContent": "This will update all tokens created from this actor, to match the new prototype token data",
+    "sidebar-context.resetDoors": "Reset Doors",
+    "sidebar-context.resetFog": "Reset Fog"
 }

--- a/scripts/sidebarContext.js
+++ b/scripts/sidebarContext.js
@@ -1,135 +1,135 @@
 RollTableDirectory.prototype._getEntryContextOptions = function newTableContext() {
-    const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
-    return [
-        {
-            name: "TABLE.Roll",
-            icon: `<i class="fas fa-dice-d20"></i>`,
-            condition: li => {
-                const table = game.tables.get(li.data("documentId"));
-                return table.data.img !== CONST.DEFAULT_TOKEN;
-            },
-            callback: li => {
-                const table = game.tables.get(li.data("documentId"));
-                table.draw()
-            }
-        }
-    ].concat(options);
+  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  return [
+    {
+      name: "TABLE.Roll",
+      icon: `<i class="fas fa-dice-d20"></i>`,
+      condition: li => {
+        const table = game.tables.get(li.data("documentId"));
+        return table.data.img !== CONST.DEFAULT_TOKEN;
+      },
+      callback: li => {
+        const table = game.tables.get(li.data("documentId"));
+        table.draw()
+      }
+    }
+  ].concat(options);
 }
 
 ActorDirectory.prototype._getEntryContextOptions = function newActorContext() {
-    const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
-    return [
-        {
-            name: "SIDEBAR.CharArt",
-            icon: '<i class="fas fa-image"></i>',
-            condition: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
-                  return actor.data.img !== CONST.DEFAULT_TOKEN;
-                }else{
-                  return false;
-                }
-            },
-            callback: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                new ImagePopout(actor.data.img, {
-                    title: actor.name,
-                    shareable: true,
-                    uuid: actor.uuid
-                }).render(true);
-            }
-        },
-        {
-            name: "SIDEBAR.TokenArt",
-            icon: '<i class="fas fa-image"></i>',
-            condition: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
-                  if (actor.data.token.randomImg) return false;
-                  return ![null, undefined, CONST.DEFAULT_TOKEN].includes(actor.data.token.img);
-                }else{
-                  return false;
-                }
-            },
-            callback: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                new ImagePopout(actor.data.token.img, {
-                    title: actor.name,
-                    shareable: true,
-                    uuid: actor.uuid
-                }).render(true);
-            }
-        },
-        {
-            name: "sidebar-context.prototype",
-            icon: '<i class="fas fa-user circle"></i>',
-            condition: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
-                  return true;
-                }else{
-                  return false;
-                }
-            },
-            callback: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                new CONFIG.Token.prototypeSheetClass(actor, {
-                    left: Math.max(this.position.left - 560 - 10, 10),
-                    top: this.position.top
-                }).render(true);
-            }
-        },
-        {
-            name: "sidebar-context.updateChildren",
-            icon: `<i class="fas fa-user-edit"></i>`,
-            condition: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
-                  return !actor.data.token.actorLink;
-                }else{
-                  return false;
-                }
-            },
-            callback: li => {
-                const actor = game.actors.get(li.data("documentId"));
-                updateChildren.call(actor)
-            }
+  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  return [
+    {
+      name: "SIDEBAR.CharArt",
+      icon: '<i class="fas fa-image"></i>',
+      condition: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        if (game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))) {
+          return actor.data.img !== CONST.DEFAULT_TOKEN;
+        } else {
+          return false;
         }
-    ].concat(options);
+      },
+      callback: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        new ImagePopout(actor.data.img, {
+          title: actor.name,
+          shareable: true,
+          uuid: actor.uuid
+        }).render(true);
+      }
+    },
+    {
+      name: "SIDEBAR.TokenArt",
+      icon: '<i class="fas fa-image"></i>',
+      condition: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        if (game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))) {
+          if (actor.data.token.randomImg) return false;
+          return ![null, undefined, CONST.DEFAULT_TOKEN].includes(actor.data.token.img);
+        } else {
+          return false;
+        }
+      },
+      callback: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        new ImagePopout(actor.data.token.img, {
+          title: actor.name,
+          shareable: true,
+          uuid: actor.uuid
+        }).render(true);
+      }
+    },
+    {
+      name: "sidebar-context.prototype",
+      icon: '<i class="fas fa-user circle"></i>',
+      condition: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        if (game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))) {
+          return true;
+        } else {
+          return false;
+        }
+      },
+      callback: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        new CONFIG.Token.prototypeSheetClass(actor, {
+          left: Math.max(this.position.left - 560 - 10, 10),
+          top: this.position.top
+        }).render(true);
+      }
+    },
+    {
+      name: "sidebar-context.updateChildren",
+      icon: `<i class="fas fa-user-edit"></i>`,
+      condition: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        if (game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))) {
+          return !actor.data.token.actorLink;
+        } else {
+          return false;
+        }
+      },
+      callback: li => {
+        const actor = game.actors.get(li.data("documentId"));
+        updateChildren.call(actor)
+      }
+    }
+  ].concat(options);
 }
 
 
 ItemDirectory.prototype._getEntryContextOptions = function newItemContext() {
-    const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
-    return [
-        {
-            name: "ITEM.ViewArt",
-            icon: '<i class="fas fa-image"></i>',
-            condition: li => {
-                const item = game.items.get(li.data("documentId"));
-                return item.data.img !== CONST.DEFAULT_TOKEN;
-            },
-            callback: li => {
-                const item = game.items.get(li.data("documentId"));
-                new ImagePopout(item.data.img, {
-                    title: item.name,
-                    shareable: true,
-                    uuid: item.uuid
-                }).render(true);
-            }
-        },
-        {
-            name: "sidebar-context.displayChat",
-            icon: `<i class="fas fa-dice-d20"></i>`,
-            condition: li => {
-                return true
-            },
-            callback: li => {
-                const item = game.items.get(li.data("documentId"));
-                newChatCard.call(item)
-            }
-        },
-    ].concat(options);
+  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  return [
+    {
+      name: "ITEM.ViewArt",
+      icon: '<i class="fas fa-image"></i>',
+      condition: li => {
+        const item = game.items.get(li.data("documentId"));
+        return item.data.img !== CONST.DEFAULT_TOKEN;
+      },
+      callback: li => {
+        const item = game.items.get(li.data("documentId"));
+        new ImagePopout(item.data.img, {
+          title: item.name,
+          shareable: true,
+          uuid: item.uuid
+        }).render(true);
+      }
+    },
+    {
+      name: "sidebar-context.displayChat",
+      icon: `<i class="fas fa-dice-d20"></i>`,
+      condition: li => {
+        return true
+      },
+      callback: li => {
+        const item = game.items.get(li.data("documentId"));
+        newChatCard.call(item)
+      }
+    },
+  ].concat(options);
 }
 
 SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext() {
@@ -162,7 +162,7 @@ SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext
   ].concat(options);
 }
 
-SceneDirectory.prototype._getFolderContextOptions  = function newSceneFolderContext() {
+SceneDirectory.prototype._getFolderContextOptions = function newSceneFolderContext() {
   const options = SidebarDirectory.prototype._getFolderContextOptions.call(this);
   return [
     {
@@ -172,8 +172,8 @@ SceneDirectory.prototype._getFolderContextOptions  = function newSceneFolderCont
         return game.user?.isGM;
       },
       callback: (header) => {
-          const folderId = header.parent().data('folderId');
-          setNavigationForAllScenes(folderId, true);
+        const folderId = header.parent().data('folderId');
+        setNavigationForAllScenes(folderId, true);
       }
     },
     {
@@ -183,77 +183,80 @@ SceneDirectory.prototype._getFolderContextOptions  = function newSceneFolderCont
         return game.user?.isGM;
       },
       callback: (header) => {
-          const folderId = header.parent().data('folderId');
-          setNavigationForAllScenes(folderId, false);
+        const folderId = header.parent().data('folderId');
+        setNavigationForAllScenes(folderId, false);
       }
     }
   ].concat(options);
 }
 
 async function newChatCard() {
-    const templateData = {
-        item: this.data,
-        data: this.getChatData(),
-        labels: this.labels,
-        hasAttack: this.hasAttack,
-        isHealing: this.isHealing,
-        hasDamage: this.hasDamage,
-        isVersatile: this.isVersatile,
-        isSpell: this.data.type === "spell",
-        hasSave: this.hasSave,
-        hasAreaTarget: this.hasAreaTarget,
-        isTool: this.data.type === "tool",
-        hasAbilityCheck: this.hasAbilityCheck
-    };
-    const html = await renderTemplate("systems/dnd5e/templates/chat/item-card.html", templateData);
+  const templateData = {
+    item: this.data,
+    data: this.getChatData(),
+    labels: this.labels,
+    hasAttack: this.hasAttack,
+    isHealing: this.isHealing,
+    hasDamage: this.hasDamage,
+    isVersatile: this.isVersatile,
+    isSpell: this.data.type === "spell",
+    hasSave: this.hasSave,
+    hasAreaTarget: this.hasAreaTarget,
+    isTool: this.data.type === "tool",
+    hasAbilityCheck: this.hasAbilityCheck
+  };
+  const html = await renderTemplate("systems/dnd5e/templates/chat/item-card.html", templateData);
 
-    // Create the ChatMessage data object
-    const chatData = {
-        user: game.user.data._id,
-        type: CONST.CHAT_MESSAGE_TYPES.OTHER,
-        content: html,
-        flavor: this.data.data.chatFlavor || this.name,
-        flags: { "core.canPopout": true }
-    };
+  // Create the ChatMessage data object
+  const chatData = {
+    user: game.user.data._id,
+    type: CONST.CHAT_MESSAGE_TYPES.OTHER,
+    content: html,
+    flavor: this.data.data.chatFlavor || this.name,
+    flags: { "core.canPopout": true }
+  };
 
-    // Apply the roll mode to adjust message visibility
-    ChatMessage.applyRollMode(chatData, game.settings.get("core", "rollMode"));
+  // Apply the roll mode to adjust message visibility
+  ChatMessage.applyRollMode(chatData, game.settings.get("core", "rollMode"));
 
-    // Create the Chat Message or return its data
-    return ChatMessage.create(chatData)
+  // Create the Chat Message or return its data
+  return ChatMessage.create(chatData)
 }
 
 async function updateChildren() {
-    let data = this.data.token.toObject()
-    let tokArr = Array.from(game.scenes.active.data.tokens)
-    let updateArr = tokArr.filter(i => i.data.actorId === this.id)
-    let updates = updateArr.map(i =>  (Object.assign({_id: i.id}, data)))
-    new Dialog({
-        title: game.i18n.localize("sidebar-context.updateChildrenTitle"),
-        content: game.i18n.localize("sidebar-context.updateChildrenContent"),
-        buttons: {
-            one: {
-                label: game.i18n.localize("Yes"),
-                callback: () => {
-                    game.scenes.active.updateEmbeddedDocuments("Token", updates)
-                }
-            }
+  let data = this.data.token.toObject()
+  let tokArr = Array.from(game.scenes.active.data.tokens)
+  let updateArr = tokArr.filter(i => i.data.actorId === this.id)
+  let updates = updateArr.map(i => (Object.assign({ _id: i.id }, data)))
+  new Dialog({
+    title: game.i18n.localize("sidebar-context.updateChildrenTitle"),
+    content: game.i18n.localize("sidebar-context.updateChildrenContent"),
+    buttons: {
+      one: {
+        label: game.i18n.localize("Yes"),
+        callback: () => {
+          game.scenes.active.updateEmbeddedDocuments("Token", updates)
         }
-    }).render(true)
+      }
+    }
+  }).render(true)
 
 }
 
 async function resetDoors(isCurrentScene, id) {
+  let updates = []
   if (isCurrentScene) {
-    await canvas
-      .walls?.doors.filter((item) => item.data.ds == 1)
-      .forEach((item) => item.update({ ds: 0 }, {}));
+    canvas
+      .walls?.doors.filter((item) => item.data.ds === 1)
+      .forEach((item) => updates.push({ _id: item.id, ds: 0 }))
+    await canvas.scene.updateEmbeddedDocuments("Wall", updates)
   } else {
     if (id) {
-      await game
-        .scenes?.get(id)
-        ?.data.walls.filter((item) => item.data.door != 0)
-        .forEach((x) => (x.data.ds = 0));
+      let scene = game.scenes?.get(id)
+      scene
+        .data.walls.filter((item) => item.data.ds === 1)
+        .forEach((x) => updates.push({ _id: x.id, ds : 0 }))
+      await scene.updateEmbeddedDocuments("Wall", updates)
     }
   }
   ui.notifications?.info(`Doors have been shut.`);
@@ -286,8 +289,8 @@ function setNavigationForAllScenes(folder, navOn) {
   const folderObject = game.folders.get(folder) || game.folders.getName(folder);
 
   const updates = game.scenes
-      .filter((scene) => scene.data.folder === folderObject.id)
-      .map((scene) => ({ _id: scene.id, navigation: navOn }));
+    .filter((scene) => scene.data.folder === folderObject.id)
+    .map((scene) => ({ _id: scene.id, navigation: navOn }));
 
-  return Scene.update(updates);
+  return Scene.updateDocuments(updates);
 }

--- a/scripts/sidebarContext.js
+++ b/scripts/sidebarContext.js
@@ -24,7 +24,11 @@ ActorDirectory.prototype._getEntryContextOptions = function newActorContext() {
             icon: '<i class="fas fa-image"></i>',
             condition: li => {
                 const actor = game.actors.get(li.data("entityId"));
-                return actor.data.img !== CONST.DEFAULT_TOKEN;
+                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
+                  return actor.data.img !== CONST.DEFAULT_TOKEN;
+                }else{
+                  return false;
+                }
             },
             callback: li => {
                 const actor = game.actors.get(li.data("entityId"));
@@ -40,8 +44,12 @@ ActorDirectory.prototype._getEntryContextOptions = function newActorContext() {
             icon: '<i class="fas fa-image"></i>',
             condition: li => {
                 const actor = game.actors.get(li.data("entityId"));
-                if (actor.data.token.randomImg) return false;
-                return ![null, undefined, CONST.DEFAULT_TOKEN].includes(actor.data.token.img);
+                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
+                  if (actor.data.token.randomImg) return false;
+                  return ![null, undefined, CONST.DEFAULT_TOKEN].includes(actor.data.token.img);
+                }else{
+                  return false;
+                }
             },
             callback: li => {
                 const actor = game.actors.get(li.data("entityId"));
@@ -56,7 +64,12 @@ ActorDirectory.prototype._getEntryContextOptions = function newActorContext() {
             name: "sidebar-context.prototype",
             icon: '<i class="fas fa-user circle"></i>',
             condition: li => {
-                return true
+                const actor = game.actors.get(li.data("entityId"));
+                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
+                  return true;
+                }else{
+                  return false;
+                }
             },
             callback: li => {
                 const actor = game.actors.get(li.data("entityId"));
@@ -71,7 +84,11 @@ ActorDirectory.prototype._getEntryContextOptions = function newActorContext() {
             icon: `<i class="fas fa-user-edit"></i>`,
             condition: li => {
                 const actor = game.actors.get(li.data("entityId"));
-                return !actor.data.token.actorLink
+                if(game.user.isGM || (actor.owner && game.user.can("TOKEN_CONFIGURE"))){
+                  return !actor.data.token.actorLink;
+                }else{
+                  return false;
+                }
             },
             callback: li => {
                 const actor = game.actors.get(li.data("entityId"));
@@ -111,38 +128,65 @@ ItemDirectory.prototype._getEntryContextOptions = function newItemContext() {
                 const item = game.items.get(li.data("entityId"));
                 newChatCard.call(item)
             }
-        },
+        }
     ].concat(options);
 }
 
-SceneDirectory.prototype._getEntryContextOptions = function newSceneContext() {
-    const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
-    return [
-        {
-            name: 'sidebar-context.resetDoors',
-            icon: '<i class="fas fa-door-closed"></i>',
-            condition: (li) => {
-              return game.user?.isGM
-            },
-            callback: (li) => {
-              const scene = game.scenes?.get(li.data('entityId'));
-              const isCurrentScene = scene.data._id == canvas.scene?.data._id;
-              await resetDoors(isCurrentScene, scene.data._id);
-            }
-        },
-        {
-          name: 'sidebar-context.resetFog',
-          icon: '<i class="fas fa-dungeon"></i>',
-          condition: (li) => {
-            return game.user?.isGM
-          },
-          callback: (li) => {
-            const scene = game.scenes?.get(li.data('entityId'));
-            const isCurrentScene = scene.data._id == canvas.scene?.data._id;
-            await resetFog(isCurrentScene, scene.data._id);
-          }
-        }
-    ].concat(options);
+SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext() {
+  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  return [
+    {
+      name: 'sidebar-context.resetDoors',
+      icon: '<i class="fas fa-door-closed"></i>',
+      condition: (li) => {
+        return game.user?.isGM;
+      },
+      callback: (li) => {
+        const scene = game.scenes?.get(li.data('entityId'));
+        const isCurrentScene = scene.data._id == canvas.scene?.data._id;
+        await resetDoors(isCurrentScene, scene.data._id);
+      }
+    },
+    {
+      name: 'sidebar-context.resetFog',
+      icon: '<i class="fas fa-dungeon"></i>',
+      condition: (li) => {
+        return game.user?.isGM;
+      },
+      callback: (li) => {
+        const scene = game.scenes?.get(li.data('entityId'));
+        const isCurrentScene = scene.data._id == canvas.scene?.data._id;
+        await resetFog(isCurrentScene, scene.data._id);
+      }
+    }
+  ].concat(options);
+}
+
+SceneDirectory.prototype._getFolderContextOptions  = function newSceneFolderContext() {
+  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  return [
+    {
+      name: 'sidebar-context.showNavAll',
+      condition: (header) => {
+        return game.user?.isGM;
+      },
+      callback: (header) => {
+          const folderId = header.parent().data('folderId');
+          setNavigationForAllScenes(folderId, true);
+      }
+    },
+    {
+      name: 'sidebar-context.hideNavAll',
+      icon: '<i class="fas fa-eye-slash"></i>',
+      condition: (header) => {
+        return game.user?.isGM;
+      },
+      callback: (header) => {
+          const folderId = header.parent().data('folderId');
+          setNavigationForAllScenes(folderId, false);
+      }
+    }
+  ].concat(options);
 }
 
 async function newChatCard() {
@@ -230,4 +274,19 @@ async function resetFog(isCurrentScene, id = null) {
       ui.notifications?.info(`Fog of War exploration progress was reset.`);
     }
   }
+}
+
+/**
+ * Shows or hides all scenes in this folder in the navigation bar
+ * @param {string}  folder  the id or name of the folder in which to toggle permissions
+ * @param {boolean} navOn   whether navigation should be on or off for all scenes in the given folder
+ */
+function setNavigationForAllScenes(folder, navOn) {
+  const folderObject = game.folders.get(folder) || game.folders.getName(folder);
+
+  const updates = game.scenes
+      .filter((scene) => scene.data.folder === folderObject.id)
+      .map((scene) => ({ _id: scene.id, navigation: navOn }));
+
+  return Scene.update(updates);
 }

--- a/scripts/sidebarContext.js
+++ b/scripts/sidebarContext.js
@@ -141,7 +141,7 @@ SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext
       condition: (li) => {
         return game.user?.isGM;
       },
-      callback: (li) => {
+      callback: async (li) => {
         const scene = game.scenes?.get(li.data('entityId'));
         const isCurrentScene = scene.data._id == canvas.scene?.data._id;
         await resetDoors(isCurrentScene, scene.data._id);
@@ -153,7 +153,7 @@ SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext
       condition: (li) => {
         return game.user?.isGM;
       },
-      callback: (li) => {
+      callback: async (li) => {
         const scene = game.scenes?.get(li.data('entityId'));
         const isCurrentScene = scene.data._id == canvas.scene?.data._id;
         await resetFog(isCurrentScene, scene.data._id);
@@ -163,10 +163,11 @@ SceneDirectory.prototype._getEntryContextOptions = function newSceneEntryContext
 }
 
 SceneDirectory.prototype._getFolderContextOptions  = function newSceneFolderContext() {
-  const options = SidebarDirectory.prototype._getEntryContextOptions.call(this);
+  const options = SidebarDirectory.prototype._getFolderContextOptions.call(this);
   return [
     {
       name: 'sidebar-context.showNavAll',
+      icon: '<i class="fas fa-eye"></i>',
       condition: (header) => {
         return game.user?.isGM;
       },


### PR DESCRIPTION
Adds a menu to the context dropdown for the Scene Directory menus to shut all doors in the selected scene to prepare it for a fresh visit from characters. The Doors that are currently locked remain locked, and are not closed.
Adds a menu to the context dropdown for the Scene Directory menus to delete fog in the selected scene to prepare it for a fresh visit from characters. I find it useful after QAing a new map for holes in walls/doors and checking lighting, etc.
Add on the folder scene context options the two options for hide all the scene on the naviagtion bar or show all.

from #2 