### PR TITLE
Prototype token fix for v10+

### DIFF
--- a/scripts/sidebarContext.js
+++ b/scripts/sidebarContext.js
@@ -32,7 +32,11 @@ Hooks.once('init', async () => {
         },
         callback: li => {
           const actor = game.actors.get(li.data("documentId"));
-          new CONFIG.Token.prototypeSheetClass(actor).render(true);
+          if (game.version >= 10) {
+            new CONFIG.Token.prototypeSheetClass(actor.prototypeToken).render(true);
+          } else {
+            new CONFIG.Token.prototypeSheetClass(actor).render(true);
+          }
         }
       },
       {


### PR DESCRIPTION
Should fix error when trying to edit the prototype token on v10 while keeping all the same on previous versions.